### PR TITLE
Refactor main function into smaller helper functions for code readability and easier reasoning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# VSCode related
+.vscode

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const PropDev3 = `https://greendale-sbx.kuali.co:/res/kc-common/development-prop
 
 
 const krUsingNewDashboardWithIframes = false;
+const howLongToWaitForSSOLogin = 18000;
 const KrDashboardUrl = `https://usmd-stg.kuali.co/res/`;
 const PropDev1 = `https://usmd-stg.kuali.co:/res/kc-common/development-proposals/201024`;
 const PropDev2 = `https://usmd-stg.kuali.co/res/kc-common/development-proposals/200836`;
@@ -22,30 +23,14 @@ const PropDev3 = `https://usmd-stg.kuali.co:/res/kc-common/development-proposals
 
 (async () => {
 
-  // if the person clicks "ok" to start the automation - start filling things out with puppeteer
-  if (confirmedStartAutomation) {
-    //close the empty second tab just used to show the ok dialog box
-    pageTab2.close();
-    //TODO: ADD SCREENSHOTS INTO BELOW FUNCTION
-    // now do the automated changes to the proposals (later may want to use a json array or something external)
-    await doAutomatedDataEntryTasks(browser, PropDev1, krUsingNewDashboardWithIframes);
-    await doAutomatedDataEntryTasks(browser, PropDev2, krUsingNewDashboardWithIframes);
-    await doAutomatedDataEntryTasks(browser, PropDev3, krUsingNewDashboardWithIframes);
-  }
+  const browser = await launchBrowserGiveUserTimeForSSOLogin(KrDashboardUrl, howLongToWaitForSSOLogin);
 
-
+  await doAutomatedDataEntryTasks(browser, PropDev1, krUsingNewDashboardWithIframes);
+  await doAutomatedDataEntryTasks(browser, PropDev2, krUsingNewDashboardWithIframes);
+  await doAutomatedDataEntryTasks(browser, PropDev3, krUsingNewDashboardWithIframes);
 
 })();
 
-
-//open kr to main page/dashboard which will prompt to get logged into KR, including UMD SSO, etc which will allow any automation to use
-    //once the person has had time to get logged in
-    //more reliable to use a second (blank) tab to pop up the alert to start the automation - that way the first tab can continue to load
-    // if the person clicks "ok" to start the automation - start filling things out with puppeteer
-  // wait for a certain fixed amount of time for the person to get all logged into KR
-  // after timer above finishes, pop up dialog to confirm ready to start the automated data entry - evaluate will run the function in the page context (the opened page)
-  // asssuming the person clicks "OK" to proceed with the automation, close the empty second browser tab and return back the browser object so it can be used for the KR automation steps
-  // if the person clicks the cancel button - close the browser and do not start automation
 
   /**
    * Launches a browser with the KR home page, giving the user time to log in and pops up confirm to start automation

--- a/app.js
+++ b/app.js
@@ -75,14 +75,10 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal, krUsingN
 
   await clickPropDevEditButton(pdDocChildFrame);
   await clickPropDevMenuSummarySubmit(pdDocChildFrame);
+  await clickPropDevCancelProposalButton(pdDocChildFrame);
 
 
 
-
-  //next click the cancel button at the bottom of the iframe - because it pops up modal window, found that I needed to use the $eval format below instead of just a regular .click() for some reason
-  console.log(`INFO: about to click cancel button (using $eval)`);
-  await pdDocChildFrame.waitForSelector('#u9v3fcv', { visible: true });
-  await pdDocChildFrame.$eval('#u9v3fcv', el => el.click());
 
 
   // console.log(`about to click ok button on the "are you sure you want to cancel?" model popup`);
@@ -166,6 +162,19 @@ async function clickPropDevMenuSummarySubmit(propDevPageIframe) {
     propDevPageIframe.waitForNavigation(),
     propDevPageIframe.click('#u79genf'),
   ]);
+}
+
+/**
+ * Clicks the "Cancel Proposal" button at the bottom of the KR PD Summary/Submit tab after confirming the selector is loaded/present
+ *
+ * In the process of trying to get the click for this working, seemingly because it pops up modal window, found that I needed to use the $eval formatinstead of just a regular .click() for some reason
+ * 
+ * @param {Object} propDevPageIframe     A puppeteer page object that points to iframe that contains the KR Proposal Development document with the form elements/buttons being updated/automated
+ */
+async function clickPropDevCancelProposalButton(propDevPageIframe) {
+  console.log(`INFO: about to click Cancel Proposal button at bottom of Summary/Submit tab (using $eval)`);
+  await propDevPageIframe.waitForSelector('#u9v3fcv', { visible: true });
+  await propDevPageIframe.$eval('#u9v3fcv', el => el.click());
 }
 
 //---------------------ONLY USEFUL FOR WHEN KR DASHBOARD USING IFRAMES IS TURNED ON-------------------//

--- a/app.js
+++ b/app.js
@@ -75,10 +75,10 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal, krUsingN
   //fist click on edit button on the bottom (only can cancel proposals when in edit mode, not view mode) - first make sure the button is present, then click it
   console.log(`INFO: about to click on edit button`);
   await pdDocChildFrame.waitForSelector('#u15ecnpy');
-  let element = await pdDocChildFrame.$('#u15ecnpy');
-  console.log(`INFO: element for edit button: ${element}`);
-  let value = await pdDocChildFrame.evaluate(el => el.textContent, element)
-  console.log(`INFO: value for edit button: ${value}`);
+  //let element = await pdDocChildFrame.$('#u15ecnpy');
+  //console.log(`INFO: element for edit button: ${element}`);
+  //let value = await pdDocChildFrame.evaluate(el => el.textContent, element)
+  //console.log(`INFO: value for edit button: ${value}`);
   await Promise.all([
     pdDocChildFrame.waitForNavigation(),
     pdDocChildFrame.click('#u15ecnpy'),
@@ -112,7 +112,7 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal, krUsingN
   // ]);
 */
 
-  console.log(`Finished cancelling Proposal: (${directLinkToProposal})`);
+  console.log(`CSV: Finished cancelling Proposal: (${directLinkToProposal})`);
   return true; // cancelled the proposal
 }
 

--- a/app.js
+++ b/app.js
@@ -73,18 +73,8 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal, krUsingN
   // use function to keep trying until we get a tab open that has the iframe present that we need to update the proposal - using a function for this
   const pdDocChildFrame = await getIframeAfterLoadingPropDev(krUsingNewDashboardWithIframes, browser, directLinkToProposal); // await openProposalInNewTabReturnPdFrame(browser, directLinkToProposal);
 
+  await clickPropDevEditButton(pdDocChildFrame);
 
-  //fist click on edit button on the bottom (only can cancel proposals when in edit mode, not view mode) - first make sure the button is present, then click it
-  console.log(`INFO: about to click on edit button`);
-  await pdDocChildFrame.waitForSelector('#u15ecnpy');
-  //let element = await pdDocChildFrame.$('#u15ecnpy');
-  //console.log(`INFO: element for edit button: ${element}`);
-  //let value = await pdDocChildFrame.evaluate(el => el.textContent, element)
-  //console.log(`INFO: value for edit button: ${value}`);
-  await Promise.all([
-    pdDocChildFrame.waitForNavigation(),
-    pdDocChildFrame.click('#u15ecnpy'),
-  ]);
 
   //next click on Summary/Submit menu option on left side of iframe
   console.log(`INFO: about to click on summary/submit`);
@@ -151,7 +141,23 @@ async function getIframeAfterLoadingPropDev(krUsingNewDashboardWithIframes, brow
   }
 }
 
-
+/**
+ * Clicks on the Edit button at the bottom of the Prop Dev Details tab after making sure the edit button has loaded
+ *
+ * @param {Object} propDevPageIframe     A puppeteer page object that points to iframe that contains the KR Proposal Development document with the form elements/buttons being updated/automated
+ */
+async function clickPropDevEditButton(propDevPageIframe) {
+  console.log(`INFO: about to click on edit button`);
+  await propDevPageIframe.waitForSelector('#u15ecnpy');
+  //let element = await propDevPageIframe.$('#u15ecnpy');
+  //console.log(`INFO: element for edit button: ${element}`);
+  //let value = await propDevPageIframe.evaluate(el => el.textContent, element)
+  //console.log(`INFO: value for edit button: ${value}`);
+  await Promise.all([
+    propDevPageIframe.waitForNavigation(),
+    propDevPageIframe.click('#u15ecnpy'),
+  ]);
+}
 
 //---------------------ONLY USEFUL FOR WHEN KR DASHBOARD USING IFRAMES IS TURNED ON-------------------//
 

--- a/app.js
+++ b/app.js
@@ -74,15 +74,9 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal, krUsingN
   const pdDocChildFrame = await getIframeAfterLoadingPropDev(krUsingNewDashboardWithIframes, browser, directLinkToProposal); // await openProposalInNewTabReturnPdFrame(browser, directLinkToProposal);
 
   await clickPropDevEditButton(pdDocChildFrame);
+  await clickPropDevMenuSummarySubmit(pdDocChildFrame);
 
 
-  //next click on Summary/Submit menu option on left side of iframe
-  console.log(`INFO: about to click on summary/submit`);
-  await pdDocChildFrame.waitForSelector('#u79genf');
-  await Promise.all([
-    pdDocChildFrame.waitForNavigation(),
-    pdDocChildFrame.click('#u79genf'),
-  ]);
 
 
   //next click the cancel button at the bottom of the iframe - because it pops up modal window, found that I needed to use the $eval format below instead of just a regular .click() for some reason
@@ -134,7 +128,7 @@ async function getIframeAfterLoadingPropDev(krUsingNewDashboardWithIframes, brow
     return openProposalInNewTabReturnPdFrame(browser, directLinkToProposal);
   }
   else {
-    // for KR with the dashboard turned of - open the proposal in the first browser tab and then return the parent frame
+    // for KR with the dashboard turned off - open the proposal in the first browser tab and then return the parent frame
     const pageTab1 = (await browser.pages())[0];
     await pageTab1.goto(directLinkToProposal);
     return pageTab1.mainFrame();
@@ -147,8 +141,9 @@ async function getIframeAfterLoadingPropDev(krUsingNewDashboardWithIframes, brow
  * @param {Object} propDevPageIframe     A puppeteer page object that points to iframe that contains the KR Proposal Development document with the form elements/buttons being updated/automated
  */
 async function clickPropDevEditButton(propDevPageIframe) {
-  console.log(`INFO: about to click on edit button`);
+  console.log(`INFO: about to click on edit button, first step waiting for selector #u15ecnpy`);
   await propDevPageIframe.waitForSelector('#u15ecnpy');
+  console.log(`INFO: selector #u15ecnpy appears to be loaded`);
   //let element = await propDevPageIframe.$('#u15ecnpy');
   //console.log(`INFO: element for edit button: ${element}`);
   //let value = await propDevPageIframe.evaluate(el => el.textContent, element)
@@ -156,6 +151,20 @@ async function clickPropDevEditButton(propDevPageIframe) {
   await Promise.all([
     propDevPageIframe.waitForNavigation(),
     propDevPageIframe.click('#u15ecnpy'),
+  ]);
+}
+
+/**
+ * Clicks on the Proposal Development "Summary/Submit" menu option on the righthand menu, after making sure the css for that menu option has loaded
+ *
+ * @param {Object} propDevPageIframe     A puppeteer page object that points to iframe that contains the KR Proposal Development document with the form elements/buttons being updated/automated
+ */
+async function clickPropDevMenuSummarySubmit(propDevPageIframe) {
+  console.log(`INFO: about to click on summary/submit`);
+  await propDevPageIframe.waitForSelector('#u79genf');
+  await Promise.all([
+    propDevPageIframe.waitForNavigation(),
+    propDevPageIframe.click('#u79genf'),
   ]);
 }
 

--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ const PropDev3 = `https://usmd-stg.kuali.co:/res/kc-common/development-proposals
 // group: set timer to wait for login, then pop up "Start automated data entry? popup"
   // wait for a certain fixed amount of time for the person to get all logged into KR
   await initialTabForBrowser.waitForTimeout(18000)
-  console.log('Waited eighteen seconds!');
+  console.log('INFO: Waited eighteen seconds!');
   //once the person has had time to get logged in
 
 
@@ -71,19 +71,19 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal) {
 
 
   //fist click on edit button on the bottom (only can cancel proposals when in edit mode, not view mode) - first make sure the button is present, then click it
-  console.log(`about to click on edit button`);
+  console.log(`INFO: about to click on edit button`);
   await pdDocChildFrame.waitForSelector('#u15ecnpy');
   let element = await pdDocChildFrame.$('#u15ecnpy');
-  console.log(`element for edit button: ${element}`);
+  console.log(`INFO: element for edit button: ${element}`);
   let value = await pdDocChildFrame.evaluate(el => el.textContent, element)
-  console.log(`value for edit button: ${value}`);
+  console.log(`INFO: value for edit button: ${value}`);
   await Promise.all([
     pdDocChildFrame.waitForNavigation(),
     pdDocChildFrame.click('#u15ecnpy'),
   ]);
 
   //next click on Summary/Submit menu option on left side of iframe
-  console.log(`about to click on summary/submit`);
+  console.log(`INFO: about to click on summary/submit`);
   await pdDocChildFrame.waitForSelector('#u79genf');
   await Promise.all([
     pdDocChildFrame.waitForNavigation(),
@@ -92,7 +92,7 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal) {
 
 
   //next click the cancel button at the bottom of the iframe - because it pops up modal window, found that I needed to use the $eval format below instead of just a regular .click() for some reason
-  console.log(`about to click cancel button (using $eval)`);
+  console.log(`INFO: about to click cancel button (using $eval)`);
   await pdDocChildFrame.waitForSelector('#u9v3fcv', { visible: true });
   await pdDocChildFrame.$eval('#u9v3fcv', el => el.click());
 
@@ -110,7 +110,7 @@ async function doAutomatedDataEntryTasks(browser, directLinkToProposal) {
   // ]);
 */
 
-  console.log(`cancelled the proposal (${directLinkToProposal}) so returning true`);
+  console.log(`Finished cancelling Proposal: (${directLinkToProposal})`);
   return true; // cancelled the proposal
 }
 


### PR DESCRIPTION
was able to refactor both the main and data entry steps functions into individual functions that make everything much cleaner and easier to reason about, necessary for the next step of trying to process a large list of proposals. Also fixed some logic surrounding clicking on the model popup to confirm that we want to cancel the proposal in KR. It was working but didn't seem to be consistent (when it started again with loading the next proposal it was failing) - adding a promise.all wrapped around to make sure the navigation was finishing it then seemed to be working